### PR TITLE
fix: scope localStorage keys to authenticated user ID

### DIFF
--- a/apps/app/frontend/src/pages/ResumeBuilder.tsx
+++ b/apps/app/frontend/src/pages/ResumeBuilder.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useAuth } from '../hooks/useAuth';
 import { useFormData } from '../hooks/useFormData';
 import { useSidebarStorage } from '../hooks/useSidebarStorage';
 import { SECTION_TYPES } from '../data/sidebarItems';
@@ -10,6 +11,9 @@ import MainContent from '../components/layout/MainContent';
 import PreviewPanel from '../components/layout/PreviewPanel';
 
 function ResumeBuilder() {
+  const { user } = useAuth();
+  const userId = user?.id ?? '';
+
   const {
     formData,
     saveStatus,
@@ -17,9 +21,9 @@ function ResumeBuilder() {
     addSectionItem,
     updateSectionItem,
     removeSectionItem,
-  } = useFormData();
+  } = useFormData(userId);
 
-  const { sidebarItems, updateSidebarItems } = useSidebarStorage();
+  const { sidebarItems, updateSidebarItems } = useSidebarStorage(userId);
   const [activeSection, setActiveSection] = useState<string>(SECTION_TYPES.PERSONAL);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [showAdditional, setShowAdditional] = useState(false);


### PR DESCRIPTION
## Summary
- `useFormData` and `useSidebarStorage` now accept a `userId` parameter and store data under user-scoped keys (`resumeBuilder_formData_<userId>`, `resumeBuilder_sidebarItems_<userId>`)
- `ResumeBuilder` passes `user?.id ?? ''` (from `useAuth`) to both hooks, so each authenticated user has isolated storage
- One-time migration: on the first load after this change, any data found in the old unscoped key is moved to the user-scoped key and the legacy key is removed

## Test plan
- [ ] Log in as User A, fill in resume data — data saves to the user-scoped key
- [ ] Open DevTools → Application → Local Storage — confirm the key is `resumeBuilder_formData_<user-A-uuid>` (not the old unscoped key)
- [ ] Log in as User B on the same browser — confirm an empty form loads (User B's data is isolated from User A's)
- [ ] Pre-migration: manually write data into the old key `resumeBuilder_formData`, reload — confirm data is loaded and migrated to the scoped key, and the old key is removed

Closes #6