### PR TITLE
fix: derive custom section counter from existing sidebar items on mount

### DIFF
--- a/apps/app/frontend/src/pages/ResumeBuilder.tsx
+++ b/apps/app/frontend/src/pages/ResumeBuilder.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useAuth } from '../hooks/useAuth';
 import { useFormData } from '../hooks/useFormData';
 import { useSidebarStorage } from '../hooks/useSidebarStorage';
@@ -28,6 +28,16 @@ function ResumeBuilder() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [showAdditional, setShowAdditional] = useState(false);
   const [customSectionCounter, setCustomSectionCounter] = useState(1);
+
+  // Derive the counter from the highest existing custom-N ID so that adding
+  // a new custom section after a page reload never collides with an existing one.
+  useEffect(() => {
+    const max = sidebarItems
+      .filter((item) => /^custom-\d+$/.test(item.id))
+      .map((item) => parseInt(item.id.slice('custom-'.length), 10))
+      .reduce((acc, n) => Math.max(acc, n), 0);
+    setCustomSectionCounter(max + 1);
+  }, [sidebarItems]);
 
   const handleReorderItems = (newItems: SidebarItem[]) => {
     updateSidebarItems(newItems);


### PR DESCRIPTION
## Summary
- `customSectionCounter` previously always started at `1` on page reload, causing a new custom section to reuse an existing ID (e.g. `custom-1`) and silently overwrite its data
- A `useEffect` now scans the loaded `sidebarItems` for the highest `custom-N` suffix and sets the counter to `max + 1` on every load, so IDs are always unique

## Test plan
- [ ] Add two custom sections (`custom-1`, `custom-2`), reload the page
- [ ] Add another custom section — confirm it gets ID `custom-3`, not `custom-1`
- [ ] Confirm existing custom section data is preserved after reload
- [ ] Add a custom section on a fresh account (no existing items) — confirm it starts at `custom-1` as expected

Closes #7