### PR TITLE
feat: add Supabase JWT verification middleware to backend

### DIFF
--- a/apps/app/backend/package.json
+++ b/apps/app/backend/package.json
@@ -15,6 +15,7 @@
   "description": "",
   "dependencies": {
     "@google/genai": "^1.41.0",
+    "@supabase/supabase-js": "^2.97.0",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",

--- a/apps/app/backend/pnpm-lock.yaml
+++ b/apps/app/backend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@google/genai':
         specifier: ^1.41.0
         version: 1.41.0
+      '@supabase/supabase-js':
+        specifier: ^2.97.0
+        version: 2.97.0
       cors:
         specifier: ^2.8.6
         version: 2.8.6
@@ -253,6 +256,30 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@supabase/auth-js@2.97.0':
+    resolution: {integrity: sha512-2Og/1lqp+AIavr8qS2X04aSl8RBY06y4LrtIAGxat06XoXYiDxKNQMQzWDAKm1EyZFZVRNH48DO5YvIZ7la5fQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.97.0':
+    resolution: {integrity: sha512-fSaA0ZeBUS9hMgpGZt5shIZvfs3Mvx2ZdajQT4kv/whubqDBAp3GU5W8iIXy21MRvKmO2NpAj8/Q6y+ZkZyF/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/postgrest-js@2.97.0':
+    resolution: {integrity: sha512-g4Ps0eaxZZurvfv/KGoo2XPZNpyNtjth9aW8eho9LZWM0bUuBtxPZw3ZQ6ERSpEGogshR+XNgwlSPIwcuHCNww==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.97.0':
+    resolution: {integrity: sha512-37Jw0NLaFP0CZd7qCan97D1zWutPrTSpgWxAw6Yok59JZoxp4IIKMrPeftJ3LZHmf+ILQOPy3i0pRDHM9FY36Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.97.0':
+    resolution: {integrity: sha512-9f6NniSBfuMxOWKwEFb+RjJzkfMdJUwv9oHuFJKfe/5VJR8cd90qw68m6Hn0ImGtwG37TUO+QHtoOechxRJ1Yg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.97.0':
+    resolution: {integrity: sha512-kTD91rZNO4LvRUHv4x3/4hNmsEd2ofkYhuba2VMUPRVef1RCmnHtm7rIws38Fg0yQnOSZOplQzafn0GSiy6GVg==}
+    engines: {node: '>=20.0.0'}
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -277,6 +304,9 @@ packages:
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
+  '@types/phoenix@1.6.7':
+    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
+
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
@@ -288,6 +318,9 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -678,6 +711,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -1213,6 +1250,44 @@ snapshots:
       - react-native-b4a
       - supports-color
 
+  '@supabase/auth-js@2.97.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.97.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/postgrest-js@2.97.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.97.0':
+    dependencies:
+      '@types/phoenix': 1.6.7
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.97.0':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.97.0':
+    dependencies:
+      '@supabase/auth-js': 2.97.0
+      '@supabase/functions-js': 2.97.0
+      '@supabase/postgrest-js': 2.97.0
+      '@supabase/realtime-js': 2.97.0
+      '@supabase/storage-js': 2.97.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@types/body-parser@1.19.6':
@@ -1247,6 +1322,8 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/phoenix@1.6.7': {}
+
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
@@ -1258,6 +1335,10 @@ snapshots:
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
+      '@types/node': 25.2.3
+
+  '@types/ws@8.18.1':
+    dependencies:
       '@types/node': 25.2.3
 
   '@types/yauzl@2.10.3':
@@ -1713,6 +1794,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.7.2:
     dependencies:

--- a/apps/app/backend/server.ts
+++ b/apps/app/backend/server.ts
@@ -5,6 +5,7 @@ import cors from "cors";
 import rateLimit from "express-rate-limit";
 import { healthCheck, softSkills, technicalSkills } from "./src/controllers/aiController.js";
 import { generateTestPDF, convertHtmlToPdf } from "./src/controllers/pdfController.js";
+import { requireAuth } from "./src/middleware/auth.js";
 
 const app: Express = express();
 const PORT = process.env.PORT || 3001;
@@ -74,16 +75,16 @@ app.get("/api/test", (req: Request, res: Response) => {
   });
 });
 
-// Gemini integration endpoint
-app.post("/api/ai/generate", aiLimiter, healthCheck);
-app.post("/api/ai/soft-skills", aiLimiter, softSkills);
-app.post("/api/ai/technical-skills", aiLimiter, technicalSkills);
+// Gemini integration endpoint (auth + rate-limited)
+app.post("/api/ai/generate", requireAuth, aiLimiter, healthCheck);
+app.post("/api/ai/soft-skills", requireAuth, aiLimiter, softSkills);
+app.post("/api/ai/technical-skills", requireAuth, aiLimiter, technicalSkills);
 
-// PDF generation test endpoint
+// PDF generation test endpoint (no auth — dev/diagnostic only)
 app.get("/api/generate-test-pdf", generateTestPDF);
 
-// HTML to PDF conversion endpoint
-app.post("/api/html-to-pdf", pdfLimiter, convertHtmlToPdf);
+// HTML to PDF conversion endpoint (auth + rate-limited)
+app.post("/api/html-to-pdf", requireAuth, pdfLimiter, convertHtmlToPdf);
 
 // Basic error handler
 app.use((err: Error, req: Request, res: Response, next: NextFunction) => {

--- a/apps/app/backend/src/middleware/auth.ts
+++ b/apps/app/backend/src/middleware/auth.ts
@@ -1,0 +1,67 @@
+import { createClient } from "@supabase/supabase-js";
+import { Request, Response, NextFunction } from "express";
+import type { User } from "@supabase/supabase-js";
+
+// Extend the Express Request type so controllers can access req.user.
+declare global {
+  namespace Express {
+    interface Request {
+      user?: User;
+    }
+  }
+}
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error("Missing SUPABASE_URL or SUPABASE_ANON_KEY environment variables");
+}
+
+// Single client used only for token verification — no persistent sessions.
+const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false,
+    detectSessionInUrl: false,
+  },
+});
+
+/**
+ * Express middleware that verifies a Supabase JWT from the Authorization header.
+ * Attaches the verified user to req.user and calls next() on success.
+ * Returns 401 if the header is absent, malformed, or the token is invalid/expired.
+ */
+export const requireAuth = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader?.startsWith("Bearer ")) {
+    res.status(401).json({
+      success: false,
+      message: "Authorization header is required",
+    });
+    return;
+  }
+
+  const token = authHeader.slice(7); // strip "Bearer "
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser(token);
+
+  if (error || !user) {
+    res.status(401).json({
+      success: false,
+      message: "Invalid or expired token",
+    });
+    return;
+  }
+
+  req.user = user;
+  next();
+};

--- a/apps/app/frontend/src/services/AiService.ts
+++ b/apps/app/frontend/src/services/AiService.ts
@@ -1,3 +1,5 @@
+import { supabase } from '../lib/supabase';
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
 
 interface SkillSuggestionMetadata {
@@ -24,10 +26,12 @@ export class AIService {
     count: number = 8
   ): Promise<SkillSuggestionResult> {
     try {
+      const { data: { session } } = await supabase.auth.getSession();
       const response = await fetch(`${API_BASE_URL}/ai/soft-skills`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session?.access_token}`,
         },
         body: JSON.stringify({ jobTitle, currentSkills, count }),
       });
@@ -53,10 +57,12 @@ export class AIService {
     count: number = 8
   ): Promise<SkillSuggestionResult> {
     try {
+      const { data: { session } } = await supabase.auth.getSession();
       const response = await fetch(`${API_BASE_URL}/ai/technical-skills`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session?.access_token}`,
         },
         body: JSON.stringify({ jobTitle, currentSkills, count }),
       });

--- a/apps/app/frontend/src/services/PdfService.ts
+++ b/apps/app/frontend/src/services/PdfService.ts
@@ -1,3 +1,4 @@
+import { supabase } from '../lib/supabase';
 import { HtmlGenerator } from '../utils/htmlGenerator';
 import type { FormData, SidebarItem } from '../types/resume';
 
@@ -65,11 +66,13 @@ export class PdfService {
       const htmlContent = HtmlGenerator.generateHtml(templateName, formData, sidebarItems);
 
       // Step 2: Send HTML to backend for PDF conversion
+      const { data: { session } } = await supabase.auth.getSession();
       const response = await fetch(`${API_BASE_URL}/html-to-pdf`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           Accept: 'application/pdf',
+          'Authorization': `Bearer ${session?.access_token}`,
         },
         body: JSON.stringify({
           html: htmlContent,


### PR DESCRIPTION
## Summary
- New `requireAuth` middleware (`src/middleware/auth.ts`) validates the Supabase access token from the `Authorization: Bearer` header using `supabase.auth.getUser(token)` — a server-side network call that rejects expired and tampered tokens
- Applied to all routes that consume paid external services (Gemini AI + Browserless PDF), keeping health/test routes open
- Frontend `AiService` and `PdfService` now attach `Authorization: Bearer <access_token>` from the current Supabase session to every protected request
- Added `SUPABASE_URL` and `SUPABASE_ANON_KEY` to backend `.env`

## Protected routes
| Route | Before | After |
|-------|--------|-------|
| `POST /api/ai/generate` | open | `requireAuth` → `aiLimiter` |
| `POST /api/ai/soft-skills` | open | `requireAuth` → `aiLimiter` |
| `POST /api/ai/technical-skills` | open | `requireAuth` → `aiLimiter` |
| `POST /api/html-to-pdf` | open | `requireAuth` → `pdfLimiter` |
| `GET /`, `GET /api/test`, `GET /api/generate-test-pdf` | open | open (unchanged) |

## Test plan
- [ ] Log in as a valid user and trigger AI skill suggestions — confirm 200 response
- [ ] Download a resume PDF while logged in — confirm PDF is returned
- [ ] Send a request to `/api/ai/soft-skills` with no `Authorization` header — confirm 401
- [ ] Send a request with a malformed/expired token — confirm 401
- [ ] Confirm health check `GET /` still responds without a token

Closes #8