### PR TITLE
perf: remove unnecessary pre-download health check in TopNavigation

### DIFF
--- a/apps/app/frontend/src/components/layout/TopNavigation.tsx
+++ b/apps/app/frontend/src/components/layout/TopNavigation.tsx
@@ -22,13 +22,6 @@ function TopNavigation({ onMenuClick, formData, sidebarItems }: TopNavigationPro
     setIsDownloading(true);
 
     try {
-      const connectionTest = await PdfService.testConnection();
-
-      if (!connectionTest.success) {
-        alert('Backend connection failed. Make sure the server is running on port 3001.');
-        return;
-      }
-
       const result = await PdfService.downloadResumePDF(formData, sidebarItems, 'harvard');
 
       if (!result.success) {


### PR DESCRIPTION
## Summary
- Removed the `PdfService.testConnection()` call that ran before every PDF download
- It fired a `GET /api/test` round-trip solely to confirm the server was up, adding latency on every download click
- The guard was redundant: `downloadResumePDF` already handles connection failures in its own `catch` block, showing the same `alert` to the user

## Before vs After

```typescript
// Before — extra round-trip before every download
const connectionTest = await PdfService.testConnection();
if (!connectionTest.success) {
  alert('Backend connection failed...');
  return;
}
const result = await PdfService.downloadResumePDF(...);

// After — goes straight to the actual operation
const result = await PdfService.downloadResumePDF(...);
```

## Test plan
- [ ] Click Download — PDF generates and downloads normally
- [ ] Stop the backend server, click Download — error alert still appears (from `downloadResumePDF` catch)
- [ ] Confirm no extra network request to `/api/test` fires before the PDF request

Closes #10