### PR TITLE
fix: replace navigate()-during-render with <Navigate> in AuthPage

### DIFF
--- a/apps/app/frontend/src/pages/AuthPage.tsx
+++ b/apps/app/frontend/src/pages/AuthPage.tsx
@@ -1,16 +1,15 @@
-import { useNavigate } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import { Auth } from '@supabase/auth-ui-react';
 import { ThemeSupa } from '@supabase/auth-ui-shared';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../hooks/useAuth';
 
 function AuthPage() {
-  const navigate = useNavigate();
   const { user } = useAuth();
 
-  // Redirect if already authenticated
+  // Redirect already-authenticated users away from the auth page.
   if (user) {
-    navigate('/', { replace: true });
+    return <Navigate to="/" replace />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- `AuthPage` was calling `navigate('/', { replace: true })` directly in the render body — a React anti-pattern that runs an imperative side effect during the pure render phase
- Under React StrictMode this causes double-invocation and can produce warnings or stale-state bugs
- Replaced with `return <Navigate to="/" replace />` — the React Router declarative primitive built for this exact case; returning a render element is pure and safe
- `useNavigate` is no longer imported since it's no longer needed

## Before vs After

```tsx
// Before — imperative side effect during render (anti-pattern)
const navigate = useNavigate();
if (user) {
  navigate('/', { replace: true }); // called during render body ❌
}

// After — declarative, returned as a render element (correct)
if (user) {
  return <Navigate to="/" replace />; // pure render ✅
}
```

## Test plan
- [ ] Log in — confirm redirect to `/` happens correctly
- [ ] Navigate directly to `/auth` while already logged in — confirm immediate redirect to `/`
- [ ] Log out — confirm `/auth` page renders normally

Closes #11