### PR TITLE
perf: pool and reuse Puppeteer browser instance across PDF requests

### DIFF
--- a/apps/app/backend/src/lib/browserManager.ts
+++ b/apps/app/backend/src/lib/browserManager.ts
@@ -1,0 +1,82 @@
+import puppeteer, { Browser } from "puppeteer-core";
+
+let browserInstance: Browser | null = null;
+let browserPromise: Promise<Browser> | null = null;
+
+async function launchBrowser(): Promise<Browser> {
+  if (process.env.BROWSER_WS_ENDPOINT) {
+    console.log("Connecting to Browserless...");
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: process.env.BROWSER_WS_ENDPOINT,
+    });
+    console.log("Connected to Browserless successfully!");
+    browser.on("disconnected", () => {
+      console.log("Browser disconnected — will reconnect on next request.");
+      browserInstance = null;
+      browserPromise = null;
+    });
+    return browser;
+  }
+
+  console.log("Launching local Chrome...");
+  const browser = await puppeteer.launch({
+    headless: true as const,
+    args: [
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+      "--disable-dev-shm-usage",
+      "--disable-accelerated-2d-canvas",
+      "--no-first-run",
+      "--no-zygote",
+      "--disable-gpu",
+    ],
+    executablePath:
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  });
+  console.log("Local Chrome launched successfully!");
+  browser.on("disconnected", () => {
+    console.log("Browser disconnected — will relaunch on next request.");
+    browserInstance = null;
+    browserPromise = null;
+  });
+  return browser;
+}
+
+/**
+ * Returns a shared Browser instance, launching or connecting one if needed.
+ * Concurrent callers during startup all await the same promise to prevent
+ * multiple launches racing each other.
+ */
+export async function getBrowser(): Promise<Browser> {
+  if (browserInstance?.connected) {
+    return browserInstance;
+  }
+
+  if (!browserPromise) {
+    browserPromise = launchBrowser()
+      .then((b) => {
+        browserInstance = b;
+        browserPromise = null;
+        return b;
+      })
+      .catch((err) => {
+        browserPromise = null;
+        throw err;
+      });
+  }
+
+  return browserPromise;
+}
+
+/**
+ * Closes the shared browser instance. Call this on process shutdown to
+ * release the Chrome process or Browserless connection cleanly.
+ */
+export async function closeBrowser(): Promise<void> {
+  if (browserInstance) {
+    await browserInstance.close();
+    browserInstance = null;
+    browserPromise = null;
+    console.log("Browser closed.");
+  }
+}


### PR DESCRIPTION
Closes #13

## Summary
- Adds `src/lib/browserManager.ts` with a `getBrowser()` singleton that launches/connects the browser once and reuses it across all PDF requests
- Both `convertHtmlToPdf` and `generateTestPDF` now open a fresh `Page` per request and close only the page in `finally` — the browser process stays alive
- A `disconnected` event listener on the browser resets the instance, making crash recovery automatic and transparent to callers
- Concurrent startup requests share a single launch `Promise` to prevent double-launch races
- Adds `SIGTERM`/`SIGINT` handlers in `server.ts` calling `closeBrowser()` for clean teardown on shutdown

## Test plan
- [ ] Hit `/api/html-to-pdf` twice in quick succession — confirm the browser log shows one launch, not two
- [ ] Confirm each request still receives a valid PDF
- [ ] Confirm the server shuts down cleanly (no zombie Chrome process) after Ctrl+C