### PR TITLE
perf: debounce preview formData and memoize HarvardTemplate

### DIFF
--- a/apps/app/frontend/src/components/resume/HarvardTemplate.tsx
+++ b/apps/app/frontend/src/components/resume/HarvardTemplate.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { processHeaderData, processSectionData } from '../../utils/resumeDataProcessors';
 import type { FormData, SidebarItem } from '../../types/resume';
 
@@ -537,7 +538,7 @@ interface HarvardTemplateProps {
   sidebarItems: SidebarItem[];
 }
 
-export const HarvardTemplate = ({ formData, sidebarItems }: HarvardTemplateProps) => {
+export const HarvardTemplate = memo(({ formData, sidebarItems }: HarvardTemplateProps) => {
   const headerData = processHeaderData(formData);
 
   const combinedSkillsSections = ['courses', 'skills', 'technologiesSkills', 'languages', 'hobbies'];
@@ -585,6 +586,6 @@ export const HarvardTemplate = ({ formData, sidebarItems }: HarvardTemplateProps
       )}
     </div>
   );
-};
+});
 
 export default HarvardTemplate;

--- a/apps/app/frontend/src/hooks/useDebounce.ts
+++ b/apps/app/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/apps/app/frontend/src/pages/ResumeBuilder.tsx
+++ b/apps/app/frontend/src/pages/ResumeBuilder.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '../hooks/useAuth';
 import { useFormData } from '../hooks/useFormData';
 import { useSidebarStorage } from '../hooks/useSidebarStorage';
+import { useDebounce } from '../hooks/useDebounce';
 import { SECTION_TYPES } from '../data/sidebarItems';
 import type { SidebarItem } from '../types/resume';
 import type { AdditionalSectionItem } from '../data/sidebarItems';
@@ -24,6 +25,7 @@ function ResumeBuilder() {
   } = useFormData(userId);
 
   const { sidebarItems, updateSidebarItems } = useSidebarStorage(userId);
+  const debouncedFormData = useDebounce(formData, 300);
   const [activeSection, setActiveSection] = useState<string>(SECTION_TYPES.PERSONAL);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [showAdditional, setShowAdditional] = useState(false);
@@ -142,7 +144,7 @@ function ResumeBuilder() {
 
           <div className="order-last lg:order-none flex justify-center">
             <PreviewPanel
-              formData={formData}
+              formData={debouncedFormData}
               sidebarItems={sidebarItems}
               saveStatus={saveStatus}
             />


### PR DESCRIPTION
Closes #14

## Summary
- Adds `src/hooks/useDebounce.ts` — generic hook that delays propagating a value by a configurable number of ms
- `ResumeBuilder` passes `useDebounce(formData, 300)` to `PreviewPanel` instead of the live `formData`, so the preview re-renders at most once per 300ms idle period rather than on every keystroke
- `HarvardTemplate` is wrapped with `React.memo()` so it bails out of re-rendering entirely when its debounced props have not changed (e.g. `saveStatus` ticking or unrelated parent state)

## Test plan
- [ ] Type rapidly in any form field — confirm the preview updates after a short pause rather than on every character
- [ ] Confirm the preview still reflects all changes accurately when typing stops
- [ ] Confirm PDF download still works correctly (uses the live formData path, not the debounced one)