### PR TITLE
refactor: move shared API contract types to packages/types

### DIFF
--- a/apps/app/backend/package.json
+++ b/apps/app/backend/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@resuease/types": "link:../../../packages/types",
     "@google/genai": "^1.41.0",
     "@supabase/supabase-js": "^2.97.0",
     "cors": "^2.8.6",

--- a/apps/app/backend/pnpm-lock.yaml
+++ b/apps/app/backend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@google/genai':
         specifier: ^1.41.0
         version: 1.41.0
+      '@resuease/types':
+        specifier: link:../../../packages/types
+        version: link:../../../packages/types
       '@supabase/supabase-js':
         specifier: ^2.97.0
         version: 2.97.0

--- a/apps/app/backend/src/controllers/aiController.ts
+++ b/apps/app/backend/src/controllers/aiController.ts
@@ -1,5 +1,6 @@
 import { GoogleGenAI } from "@google/genai";
 import { Request, Response } from "express";
+import type { SoftSkillsBody, TechnicalSkillsBody } from "@resuease/types";
 
 // Initialize Google Gemini AI client
 const apiKey = process.env.GOOGLE_GEMINI_API_KEY;
@@ -9,20 +10,6 @@ const geminiClient = new GoogleGenAI({ apiKey });
 
 // Model name
 const MODEL_NAME = "gemini-2.5-flash-lite";
-
-interface SoftSkillsBody {
-  jobTitle: string;
-  currentSkills?: string[];
-  experienceLevel?: string;
-  count?: number;
-}
-
-interface TechnicalSkillsBody {
-  jobTitle?: string;
-  currentSkills?: string[];
-  experienceLevel?: string;
-  count?: number;
-}
 
 // HEALTH CHECK
 export const healthCheck = async (req: Request, res: Response) => {

--- a/apps/app/backend/src/controllers/pdfController.ts
+++ b/apps/app/backend/src/controllers/pdfController.ts
@@ -1,20 +1,7 @@
 import { PDFOptions, Page } from "puppeteer-core";
 import { Request, Response } from "express";
 import { getBrowser } from "../lib/browserManager.js";
-
-// Narrow the accepted PDF options to a safe subset.
-// Never accept the full PDFOptions from the client — Puppeteer's `path` option,
-// for example, would write the PDF to an arbitrary filesystem path on the server.
-interface SafePdfOptions {
-  format?: PDFOptions["format"];
-  margin?: PDFOptions["margin"];
-  printBackground?: PDFOptions["printBackground"];
-}
-
-interface HtmlToPdfBody {
-  html: string;
-  options?: SafePdfOptions;
-}
+import type { HtmlToPdfBody } from "@resuease/types";
 
 // Tags that can enable SSRF, XSS, or remote code execution inside Puppeteer.
 // <script>  — arbitrary JS execution
@@ -85,7 +72,7 @@ export const convertHtmlToPdf = async (req: Request<{}, {}, HtmlToPdfBody>, res:
     // options, which could include Puppeteer's `path` key and write the PDF
     // to an arbitrary location on the server's filesystem.
     const pdfOptions: PDFOptions = { ...defaultOptions };
-    if (options.format !== undefined) pdfOptions.format = options.format;
+    if (options.format !== undefined) pdfOptions.format = options.format as PDFOptions["format"];
     if (options.margin !== undefined) pdfOptions.margin = options.margin;
     if (options.printBackground !== undefined) pdfOptions.printBackground = options.printBackground;
 

--- a/apps/app/frontend/package.json
+++ b/apps/app/frontend/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@resuease/types": "link:../../../packages/types",
     "@supabase/auth-ui-react": "^0.4.7",
     "@supabase/auth-ui-shared": "^0.1.8",
     "@supabase/supabase-js": "^2.96.0",

--- a/apps/app/frontend/pnpm-lock.yaml
+++ b/apps/app/frontend/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     dependencies:
+      '@resuease/types':
+        specifier: link:../../../packages/types
+        version: link:../../../packages/types
       '@supabase/auth-ui-react':
         specifier: ^0.4.7
         version: 0.4.7(@supabase/supabase-js@2.97.0)

--- a/apps/app/frontend/src/services/AiService.ts
+++ b/apps/app/frontend/src/services/AiService.ts
@@ -1,23 +1,7 @@
 import { supabase } from '../lib/supabase';
+import type { SkillSuggestionData, SkillSuggestionResult } from '@resuease/types';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
-
-interface SkillSuggestionMetadata {
-  model: string;
-  jobTitle: string;
-  experienceLevel: string;
-  requestedCount: number;
-  returnedCount: number;
-}
-
-interface SkillSuggestionData {
-  suggestedSkills: string[];
-  metadata: SkillSuggestionMetadata;
-}
-
-type SkillSuggestionResult =
-  | { success: true; data: SkillSuggestionData }
-  | { success: false; error: string };
 
 export class AIService {
   static async suggestSoftSkills(

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@resuease/types",
+  "version": "0.1.0",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts"
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,45 @@
+// ─── AI endpoints ────────────────────────────────────────────────────────────
+
+export interface SoftSkillsBody {
+  jobTitle: string;
+  currentSkills?: string[];
+  experienceLevel?: string;
+  count?: number;
+}
+
+export interface TechnicalSkillsBody {
+  jobTitle?: string;
+  currentSkills?: string[];
+  experienceLevel?: string;
+  count?: number;
+}
+
+export interface SkillSuggestionMetadata {
+  model: string;
+  jobTitle: string;
+  experienceLevel: string;
+  requestedCount: number;
+  returnedCount: number;
+}
+
+export interface SkillSuggestionData {
+  suggestedSkills: string[];
+  metadata: SkillSuggestionMetadata;
+}
+
+export type SkillSuggestionResult =
+  | { success: true; data: SkillSuggestionData }
+  | { success: false; error: string };
+
+// ─── PDF endpoint ─────────────────────────────────────────────────────────────
+
+export interface HtmlToPdfOptions {
+  format?: string;
+  margin?: { top?: string; right?: string; bottom?: string; left?: string };
+  printBackground?: boolean;
+}
+
+export interface HtmlToPdfBody {
+  html: string;
+  options?: HtmlToPdfOptions;
+}


### PR DESCRIPTION
## Summary
- Creates `packages/types/` as a minimal `@resuease/types` package containing TypeScript types that cross the frontend/backend API boundary
- Wires both apps via pnpm `link:` — no workspace root required
- Removes duplicate inline definitions from `AiService.ts`, `aiController.ts`, and `pdfController.ts`

## Types moved
| Type | From | Now in |
|---|---|---|
| `SoftSkillsBody` | `aiController.ts` | `@resuease/types` |
| `TechnicalSkillsBody` | `aiController.ts` | `@resuease/types` |
| `SkillSuggestionMetadata` | `AiService.ts` | `@resuease/types` |
| `SkillSuggestionData` | `AiService.ts` | `@resuease/types` |
| `SkillSuggestionResult` | `AiService.ts` | `@resuease/types` |
| `HtmlToPdfBody` | `pdfController.ts` | `@resuease/types` |
| `HtmlToPdfOptions` | `pdfController.ts` | `@resuease/types` |

## Test plan
- [x] All 33 tests pass (27 frontend, 6 backend)
- [x] `tsc --noEmit` clean on the backend
- [x] Both lockfiles updated and committed

Closes #21