### PR TITLE
feat: add backend startup configuration validator

### DIFF
--- a/apps/app/backend/server.ts
+++ b/apps/app/backend/server.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import "./src/lib/validateConfig.js"; // exits with a clear error if any required env var is missing
 
 import express, { type Express, Request, Response, NextFunction } from "express";
 import cors from "cors";

--- a/apps/app/backend/src/__tests__/lib/validateConfig.test.ts
+++ b/apps/app/backend/src/__tests__/lib/validateConfig.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+
+// vitest.setup.ts sets all required env vars before this module is imported,
+// so the module-level side effect (process.exit) will not fire during tests.
+import { getMissingVars } from '../../lib/validateConfig.js';
+
+describe('getMissingVars', () => {
+  it('returns an empty array when all required variables are present', () => {
+    const result = getMissingVars({
+      SUPABASE_URL: 'https://test.supabase.co',
+      SUPABASE_ANON_KEY: 'anon-key',
+      GOOGLE_GEMINI_API_KEY: 'gemini-key',
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('reports all three variables when the env is empty', () => {
+    const result = getMissingVars({});
+    const names = result.map((v) => v.name);
+
+    expect(names).toContain('SUPABASE_URL');
+    expect(names).toContain('SUPABASE_ANON_KEY');
+    expect(names).toContain('GOOGLE_GEMINI_API_KEY');
+  });
+
+  it('reports only the variables that are missing, not the ones that are present', () => {
+    const result = getMissingVars({ SUPABASE_URL: 'https://test.supabase.co' });
+    const names = result.map((v) => v.name);
+
+    expect(names).not.toContain('SUPABASE_URL');
+    expect(names).toContain('SUPABASE_ANON_KEY');
+    expect(names).toContain('GOOGLE_GEMINI_API_KEY');
+  });
+
+  it('includes a human-readable description for each missing variable', () => {
+    const result = getMissingVars({});
+
+    for (const v of result) {
+      expect(v.description.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/app/backend/src/lib/validateConfig.ts
+++ b/apps/app/backend/src/lib/validateConfig.ts
@@ -1,0 +1,36 @@
+const REQUIRED_VARS = [
+  {
+    name: 'SUPABASE_URL',
+    description: 'Supabase project URL (required by auth middleware)',
+  },
+  {
+    name: 'SUPABASE_ANON_KEY',
+    description: 'Supabase anonymous key (required by auth middleware)',
+  },
+  {
+    name: 'GOOGLE_GEMINI_API_KEY',
+    description: 'Google Gemini API key (required for AI endpoints)',
+  },
+] as const;
+
+type VarSpec = { name: string; description: string };
+
+/**
+ * Returns every required variable that is absent or empty in the given env map.
+ * Accepts an explicit env object so it can be called with a mock in tests.
+ */
+export function getMissingVars(env: NodeJS.ProcessEnv = process.env): VarSpec[] {
+  return REQUIRED_VARS.filter(({ name }) => !env[name]);
+}
+
+// Validate on import — exit immediately with a full list of missing variables
+// rather than letting individual modules fail one at a time.
+const missing = getMissingVars();
+
+if (missing.length > 0) {
+  const lines = missing
+    .map(({ name, description }) => `  ${name}: ${description}`)
+    .join('\n');
+  console.error(`Server cannot start — missing required environment variables:\n${lines}`);
+  process.exit(1);
+}

--- a/apps/app/backend/tsconfig.json
+++ b/apps/app/backend/tsconfig.json
@@ -12,6 +12,6 @@
     "declaration": true,
     "resolveJsonModule": true
   },
-  "include": ["server.ts", "src/**/*.ts"],
+  "include": ["server.ts", "vitest.setup.ts", "src/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/app/backend/vitest.setup.ts
+++ b/apps/app/backend/vitest.setup.ts
@@ -1,4 +1,5 @@
 // Set required environment variables before any test module is imported.
-// auth.ts reads these at module load time and throws if they are absent.
+// auth.ts and validateConfig.ts read these at module load time and exit/throw if absent.
 process.env.SUPABASE_URL = 'https://test.supabase.co';
 process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+process.env.GOOGLE_GEMINI_API_KEY = 'test-gemini-key';


### PR DESCRIPTION
## Summary
- Creates `src/lib/validateConfig.ts` with a `getMissingVars()` function that checks all required env vars in one pass
- Imported in `server.ts` immediately after `dotenv/config`, before any controller or middleware module runs
- If any variable is missing the server exits with a clear, complete list instead of crashing mid-startup with a cryptic module error
- Adds 4 tests for `getMissingVars`; also fixes `tsconfig.json` to include `vitest.setup.ts` so `@types/node` applies to it

## Required variables validated
| Variable | Purpose |
|---|---|
| `SUPABASE_URL` | Auth middleware — Supabase project URL |
| `SUPABASE_ANON_KEY` | Auth middleware — Supabase anonymous key |
| `GOOGLE_GEMINI_API_KEY` | AI controller — Gemini API access |

## Before vs after
**Before** — missing `GOOGLE_GEMINI_API_KEY` gives:
```
Error: Missing Gemini API key
    at file:///app/src/controllers/aiController.js:6:...
```
One variable. No context. Other missing vars hidden until next restart.

**After** — same scenario gives:
```
Server cannot start — missing required environment variables:
  GOOGLE_GEMINI_API_KEY: Google Gemini API key (required for AI endpoints)
```

## Test plan
- [x] 10 backend tests pass (4 new validateConfig + 6 existing auth)
- [x] `tsc --noEmit` clean

Closes #22